### PR TITLE
added 'no rows returned' in case of empty tables

### DIFF
--- a/lib/sqlite_viewer_values.dart
+++ b/lib/sqlite_viewer_values.dart
@@ -26,17 +26,12 @@ class _DataListState extends State<DataList> {
   Widget build(BuildContext context) {
     return Scaffold(
         appBar: AppBar(title: Text(widget.tableName)),
-        body: Container(
-            padding: const EdgeInsets.all(20.0), child: _getWidget(context)));
+        body: Container(padding: const EdgeInsets.all(20.0), child: _getWidget(context)));
   }
 
   Future<List?> _getValues() async {
     final db = await openDatabase(widget.databasePath);
-    final values = await db.rawQuery('SELECT * FROM ${widget.tableName}');
-    if (values.isNotEmpty) {
-      return values;
-    }
-    return null;
+    return await db.rawQuery('SELECT * FROM ${widget.tableName}');
   }
 
   FutureBuilder<List?> _getWidget(BuildContext context) {
@@ -44,53 +39,53 @@ class _DataListState extends State<DataList> {
       future: _values,
       builder: (context, snapshot) {
         if (snapshot.hasData) {
-          return JsonTable(
-            snapshot.data ?? [],
-            tableHeaderBuilder: (String? header) {
-              return Container(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 8.0,
-                  vertical: 4.0,
-                ),
-                decoration: BoxDecoration(
-                  border: Border.all(width: 0.5),
-                  color: Colors.grey[300],
-                ),
-                child: Text(
-                  header ?? '',
-                  textAlign: TextAlign.center,
-                  style: Theme.of(context).textTheme.headline4?.copyWith(
-                        fontWeight: FontWeight.w700,
-                        fontSize: 14.0,
-                        color: Colors.black87,
-                      ),
-                ),
-              );
-            },
-            tableCellBuilder: (value) {
-              return Container(
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 4.0, vertical: 2.0),
-                decoration: BoxDecoration(
-                  border: Border.all(
-                    width: 0.5,
-                    color: Colors.grey.withOpacity(0.5),
+          if (snapshot.data!.isNotEmpty) {
+            return JsonTable(
+              snapshot.data ?? [],
+              tableHeaderBuilder: (String? header) {
+                return Container(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 8.0,
+                    vertical: 4.0,
                   ),
-                ),
-                child: Text(
-                  value.toString(),
-                  textAlign: TextAlign.center,
-                  style: Theme.of(context)
-                      .textTheme
-                      .headline4
-                      ?.copyWith(fontSize: 14.0, color: Colors.grey[900]),
-                ),
-              );
-            },
-            allowRowHighlight: true,
-            rowHighlightColor: Colors.yellow[500]?.withOpacity(0.7),
-            paginationRowCount: snapshot.data?.length,
-          );
+                  decoration: BoxDecoration(
+                    border: Border.all(width: 0.5),
+                    color: Colors.grey[300],
+                  ),
+                  child: Text(
+                    header ?? '',
+                    textAlign: TextAlign.center,
+                    style: Theme.of(context).textTheme.headline4?.copyWith(
+                          fontWeight: FontWeight.w700,
+                          fontSize: 14.0,
+                          color: Colors.black87,
+                        ),
+                  ),
+                );
+              },
+              tableCellBuilder: (value) {
+                return Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 4.0, vertical: 2.0),
+                  decoration: BoxDecoration(
+                    border: Border.all(
+                      width: 0.5,
+                      color: Colors.grey.withOpacity(0.5),
+                    ),
+                  ),
+                  child: Text(
+                    value.toString(),
+                    textAlign: TextAlign.center,
+                    style: Theme.of(context).textTheme.headline4?.copyWith(fontSize: 14.0, color: Colors.grey[900]),
+                  ),
+                );
+              },
+              allowRowHighlight: true,
+              rowHighlightColor: Colors.yellow[500]?.withOpacity(0.7),
+              paginationRowCount: snapshot.data?.length,
+            );
+          } else {
+            return const Center(child: Text("No rows returned"));
+          }
         } else if (snapshot.hasError) {
           return Text("${snapshot.error}");
         }


### PR DESCRIPTION
solving issue #12: relocated the isEmpty test inside the builder of the Future _getWidget, so that the snapshot HasData == true but snapshot.data.isEmpty is also true (empty table). Before it gets to JsonTable (and trigger an assert), the test returns a Text widget with the "No rows returned" content.